### PR TITLE
Fix issues wrt missing port in URL and too strict websocket upgrade response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,47 @@ Connection from ('192.168.1.11', 1883)
 > Hello esp8266 1.5.4(baaeaebb) v1.8.3-80-g1f61fe0-dirty on 2016-08-31 ESP module with ESP8266!
 ```
 
+## Example client against 'ws://echo.websocket.org/'
+
+Change [c22e4be](commit/c22e4be2142dc2335d35cb2046c969eb3d29dac0) defaults to port 80 if no port is provided in URL, and allows for all upgrade responses starting with 'HTTP/1.1 101 '.
+
+Based on that, this is minimal example going against 'ws://echo.websocket.org/':
+
+```
+$ webrepl_cli.py echo_websocket_org.py 192.168.3.1:
+Password: 
+op:put, host:192.168.3.1, port:8266, passwd:abcd.
+echo_websocket_org.py -> /echo_websocket_org.py
+Remote WebREPL version: (1, 9, 4)
+Sent 162 of 162 bytes
+$ 
+$ webrepl_client.py 192.168.3.1
+Password: 
+
+WebREPL connected
+>>> 
+>>> 
+MicroPython v1.9.4-272-g46091b8a on 2018-07-18; ESP module with ESP8266
+Type "help()" for more information.
+>>> import echo_websocket_org
+fo0bAr
+
+>>> exit
+### closed ###
+$ 
+$ cat echo_websocket_org.py 
+import uwebsockets.client
+
+websocket = uwebsockets.client.connect("ws://echo.websocket.org/")
+
+websocket.send("fo0bAr\r\n")
+
+resp = websocket.recv()
+
+print(resp)
+$ 
+```
+
 # Micropython Socket.io
 
 An implementation of socket.io and engine.io for the ESP8266 (client only ATM).

--- a/README.md
+++ b/README.md
@@ -29,20 +29,10 @@ Connection from ('192.168.1.11', 1883)
 > Hello esp8266 1.5.4(baaeaebb) v1.8.3-80-g1f61fe0-dirty on 2016-08-31 ESP module with ESP8266!
 ```
 
-## Example client against 'ws://echo.websocket.org/'
+## Minimal example client against 'ws://echo.websocket.org/'
 
-Change [c22e4be](../../commit/c22e4be2142dc2335d35cb2046c969eb3d29dac0) defaults to port 80 if no port is provided in URL, and allows for all upgrade responses starting with 'HTTP/1.1 101 '.
-
-Based on that, this is minimal example going against 'ws://echo.websocket.org/':
 
 ```
-$ webrepl_cli.py echo_websocket_org.py 192.168.3.1:
-Password: 
-op:put, host:192.168.3.1, port:8266, passwd:abcd.
-echo_websocket_org.py -> /echo_websocket_org.py
-Remote WebREPL version: (1, 9, 4)
-Sent 162 of 162 bytes
-$ 
 $ webrepl_client.py 192.168.3.1
 Password: 
 
@@ -52,21 +42,19 @@ WebREPL connected
 MicroPython v1.9.4-272-g46091b8a on 2018-07-18; ESP module with ESP8266
 Type "help()" for more information.
 >>> import echo_websocket_org
-fo0bAr
+The quick brown fox jumps over the lazy dog
 
->>> exit
+>>> 
 ### closed ###
 $ 
 $ cat echo_websocket_org.py 
 import uwebsockets.client
-
 websocket = uwebsockets.client.connect("ws://echo.websocket.org/")
-
-websocket.send("fo0bAr\r\n")
-
+mesg = "The quick brown fox jumps over the lazy dog"
+websocket.send(mesg + "\r\n")
 resp = websocket.recv()
-
 print(resp)
+assert(mesg + "\r\n" == resp)
 $ 
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Connection from ('192.168.1.11', 1883)
 
 ## Example client against 'ws://echo.websocket.org/'
 
-Change [c22e4be](commit/c22e4be2142dc2335d35cb2046c969eb3d29dac0) defaults to port 80 if no port is provided in URL, and allows for all upgrade responses starting with 'HTTP/1.1 101 '.
+Change [c22e4be](../../commit/c22e4be2142dc2335d35cb2046c969eb3d29dac0) defaults to port 80 if no port is provided in URL, and allows for all upgrade responses starting with 'HTTP/1.1 101 '.
 
 Based on that, this is minimal example going against 'ws://echo.websocket.org/':
 

--- a/examples/echo_websocket_org.py
+++ b/examples/echo_websocket_org.py
@@ -1,0 +1,9 @@
+import uwebsockets.client
+
+websocket = uwebsockets.client.connect("ws://echo.websocket.org/")
+
+websocket.send("fo0bAr\r\n")
+
+resp = websocket.recv()
+
+print(resp)

--- a/examples/echo_websocket_org.py
+++ b/examples/echo_websocket_org.py
@@ -1,9 +1,7 @@
 import uwebsockets.client
-
 websocket = uwebsockets.client.connect("ws://echo.websocket.org/")
-
-websocket.send("fo0bAr\r\n")
-
+mesg = "The quick brown fox jumps over the lazy dog"
+websocket.send(mesg + "\r\n")
 resp = websocket.recv()
-
 print(resp)
+assert(mesg + "\r\n" == resp)

--- a/uwebsockets/client.py
+++ b/uwebsockets/client.py
@@ -52,7 +52,7 @@ def connect(uri):
     send_header(b'')
 
     header = sock.readline()[:-2]
-    assert header == b'HTTP/1.1 101 Switching Protocols', header
+    assert header.startswith(b'HTTP/1.1 101 '), header
 
     # We don't (currently) need these headers
     # FIXME: should we check the return key?

--- a/uwebsockets/protocol.py
+++ b/uwebsockets/protocol.py
@@ -38,7 +38,8 @@ def urlparse(uri):
     """Parse ws:// URLs"""
     match = URL_RE.match(uri)
     if match:
-        return URI(match.group(1), int(match.group(2)), match.group(3))
+        port = int(80 if match.group(2)==None else match.group(2))
+        return URI(match.group(1), port, match.group(3))
 
 
 class Websocket:

--- a/uwebsockets/protocol.py
+++ b/uwebsockets/protocol.py
@@ -38,8 +38,14 @@ def urlparse(uri):
     """Parse ws:// URLs"""
     match = URL_RE.match(uri)
     if match:
-        port = int(80 if match.group(2)==None else match.group(2))
-        return URI(match.group(1), port, match.group(3))
+        _, host, port, path = (match.group(i) for i in range(4))
+        if port is None:
+            port = 80
+
+        assert host
+        assert port
+
+        return URI(host, port, path)
 
 
 class Websocket:

--- a/uwebsockets/protocol.py
+++ b/uwebsockets/protocol.py
@@ -38,7 +38,7 @@ def urlparse(uri):
     """Parse ws:// URLs"""
     match = URL_RE.match(uri)
     if match:
-        _, host, port, path = (match.group(i) for i in range(4))
+        host, port, path = match.group(1), match.group(2), match.group(3)
         if port is None:
             port = 80
 


### PR DESCRIPTION
Adds new "examples/echo_websocket_org.py" client going against "ws://echo.websocket.org/"