### PR TITLE
Readd now missing int() conversion for port

### DIFF
--- a/uwebsockets/protocol.py
+++ b/uwebsockets/protocol.py
@@ -45,7 +45,7 @@ def urlparse(uri):
         assert host
         assert port
 
-        return URI(host, port, path)
+        return URI(host, int(port), path)
 
 
 class Websocket:


### PR DESCRIPTION
I did test websocket client going against "ws://192.168.4.1:8266/" today (from module with AP 192.168.3.1), with specifying port. The many edits yesterday did remove the needed int() conversion for port in case port is provided in URL.

With below script the 192.168.3.1 ESP-01s remote controls the 192.168.4.1 ESP-01s, flipping that modules builtin LED every second -- could be another example, or at least basis of an example (the sta_if configuration is in my boot.py, could go here as well):

```
$ cat flip.py 
import uwebsockets.client
import time
from machine import Pin

websocket = uwebsockets.client.connect('ws://192.168.4.1:8266/')

def wait_for_prompt():
    resp = ""
    while not(">>> " in resp):
        resp = websocket.recv()
        print("< {}".format(resp))

def do(cmd):
    websocket.send(cmd+"\r\n")
    wait_for_prompt()

resp = websocket.recv()
assert resp == "Password: ", resp

do("abcd")

do("import machine")

do("led = machine.Pin(1, machine.Pin.OUT)")

while True:
    do("led.value(0)")
    time.sleep(1)
    do("led.value(1)")
    time.sleep(1)
$
```
