### PR TITLE
Raise exception when socket dies

### DIFF
--- a/uwebsockets/protocol.py
+++ b/uwebsockets/protocol.py
@@ -188,7 +188,7 @@ class Websocket:
             except ValueError:
                 LOGGER.debug("Failed to read frame. Socket dead.")
                 self._close()
-                raise ConnectionClosed
+                raise ConnectionClosed()
 
             if not fin:
                 raise NotImplementedError()

--- a/uwebsockets/protocol.py
+++ b/uwebsockets/protocol.py
@@ -36,6 +36,9 @@ URI = namedtuple('URI', ('protocol', 'hostname', 'port', 'path'))
 class NoDataException(Exception):
     pass
 
+class ConnectionClosed(Exception):
+    pass
+
 def urlparse(uri):
     """Parse ws:// URLs"""
     match = URL_RE.match(uri)
@@ -183,9 +186,10 @@ class Websocket:
             except NoDataException:
                 return ''
             except ValueError:
+                print("Failed to read frame. Socket dead.")
                 LOGGER.debug("Failed to read frame. Socket dead.")
                 self._close()
-                return
+                raise ConnectionClosed
 
             if not fin:
                 raise NotImplementedError()

--- a/uwebsockets/protocol.py
+++ b/uwebsockets/protocol.py
@@ -186,7 +186,6 @@ class Websocket:
             except NoDataException:
                 return ''
             except ValueError:
-                print("Failed to read frame. Socket dead.")
                 LOGGER.debug("Failed to read frame. Socket dead.")
                 self._close()
                 raise ConnectionClosed


### PR DESCRIPTION
Hi @danni , I have modified the code so that a `ConnectionClosed` exception is raised by `recv` when the socket has died. This makes it more straightforward to handle broken connections in a client application.

Please let me know if this is something of interest and whether that would be the right way to handle this.