### PR TITLE
Fix AssertionError: b'HTTP/1.1 400 BAD REQUEST' I was getting when ru…

### DIFF
--- a/uwebsockets/client.py
+++ b/uwebsockets/client.py
@@ -50,7 +50,10 @@ def connect(uri):
     send_header(b'Upgrade: websocket')
     send_header(b'Sec-WebSocket-Key: %s', key)
     send_header(b'Sec-WebSocket-Version: 13')
-    send_header(b'Origin: http://localhost')
+    send_header(b'Origin: http://{hostname}:{port}'.format(
+        hostname=uri.hostname,
+        port=uri.port)
+    )
     send_header(b'')
 
     header = sock.readline()[:-2]


### PR DESCRIPTION
Fix `AssertionError: b'HTTP/1.1 400 BAD REQUEST'` I was getting when running
the example `socketio_client.py` on NodeMCU, and trying to connect to
Flask-SocketIO version 4.2.1