### PR TITLE
Update client.py force to request ipv4 and tcp

### DIFF
--- a/uwebsockets/client.py
+++ b/uwebsockets/client.py
@@ -31,7 +31,7 @@ def connect(uri):
                                 uri.hostname, uri.port)
 
     sock = socket.socket()
-    addr = socket.getaddrinfo(uri.hostname, uri.port)
+    addr = socket.getaddrinfo(uri.hostname, uri.port, socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(addr[0][4])
     if uri.protocol == 'wss':
         sock = ussl.wrap_socket(sock, server_hostname=uri.hostname)


### PR DESCRIPTION
When getaddrinfo also return IPv6 then program getting OSError: 124. This patch to ensure getaddrinfo only return IPv4 with TCP protocol.

Before:
[(10, 2, 6, 'echo.websocket.org', bytearray(b'\n\x00\x01\xbb\x00\x00\x00\x00*\t\x82\x80\x00\x01\x00\x00\x00\x00\x00\x00\x007\xb5\xc3\x00\x00\x00\x00')), (10, 1, 17, 'echo.websocket.org', bytearray(b'\n\x00\x01\xbb\x00\x00\x00\x00*\t\x82\x80\x00\x01\x00\x00\x00\x00\x00\x00\x007\xb5\xc3\x00\x00\x00\x00')), (2, 2, 6, 'echo.websocket.org', bytearray(b'\x02\x00\x01\xbbB\xf1|w\x00\x00\x00\x00\x00\x00\x00\x00')), (2, 1, 17, 'echo.websocket.org', bytearray(b'\x02\x00\x01\xbbB\xf1|w\x00\x00\x00\x00\x00\x00\x00\x00'))]

after:
[(2, 2, 6, 'echo.websocket.org', bytearray(b'\x02\x00\x01\xbbB\xf1|w\x00\x00\x00\x00\x00\x00\x00\x00'))]